### PR TITLE
Stage_3: cleaning service-policy input

### DIFF
--- a/NX36-L/Nexus_9k_STage_3.py
+++ b/NX36-L/Nexus_9k_STage_3.py
@@ -330,7 +330,8 @@ def clean_if_cfg(cfg):
         r'spanning-tree bpduguard enable',
         r'no ip address',
         r'switchport trunk encapsulation dot1q',
-        r'speed nonegotiate')
+        r'speed nonegotiate',
+        r'service-policy input')
 
     intf_obj_list = parse.find_objects(r'^interface')
     for intf_obj in intf_obj_list:


### PR DESCRIPTION
Added "service-policy input" to clean_if_cfg() function, to clean 6500's
interfaces configured with policer (we verified policer are useless now-
not 1Gb/s link PE-CE anymore and those policer never cut traffic)